### PR TITLE
Use official go mongo driver

### DIFF
--- a/csv/csv_import.go
+++ b/csv/csv_import.go
@@ -1,33 +1,42 @@
 package csv
 
 import (
-	"log"
-
-	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
+	"context"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // CSVImport func to import csv records to mongodb
-func CSVImport(collection *mgo.Collection, records [][]string, start, end int) int {
+
+func CSVImport(collection *mongo.Collection, records [][]string, start, end int) int {
 	sliceOfRecords := make([][]string, len(records))
 	copy(sliceOfRecords, records)
+
 	colNames := sliceOfRecords[0]
 
-	bulk := collection.Bulk()
-	bulk.Unordered()
+	var bulkModels []mongo.WriteModel
 
 	for i := start; i < end; i++ {
 		bsonData := make(bson.M)
 		for j := 0; j < len(colNames); j++ {
 			bsonData[colNames[j]] = records[i][j]
 		}
-		bulk.Insert(bsonData)
+		bulkModels = append(bulkModels, mongo.NewInsertOneModel().SetDocument(bsonData))
 	}
-	_, err := bulk.Run()
+
+	ctx := context.TODO()
+
+	_, err := collection.BulkWrite(ctx, bulkModels)
+
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 		return 0
 	}
-	count, _ := collection.Count()
-	return count
+
+	count, err := collection.CountDocuments(ctx, bson.D{})
+	if err != nil {
+		panic(err)
+		return 0
+	}
+	return int(count)
 }

--- a/json/json_import.go
+++ b/json/json_import.go
@@ -1,26 +1,48 @@
 package json
 
 import (
-	"log"
-
-	"gopkg.in/mgo.v2"
+	"context"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // JSONImport function import/write json contents into a mongodb collection
-func JSONImport(collection *mgo.Collection, contents map[string]interface{}) (int, error) {
-	bulk := collection.Bulk()
-	bulk.Unordered()
+//func JSONImport(collection *mgo.Collection, contents map[string]interface{}) (int, error) {
+//	bulk := collection.Bulk()
+//	bulk.Unordered()
+//
+//	bulk.Insert(contents)
+//	_, err := bulk.Run()
+//	if err != nil {
+//		log.Fatal(err)
+//		return 0, err
+//	}
+//	count, err := collection.Count()
+//	if err != nil {
+//		log.Fatal(err)
+//		return 0, err
+//	}
+//	return count, nil
+//}
 
-	bulk.Insert(contents)
-	_, err := bulk.Run()
+func JSONImport(collection *mongo.Collection, contents map[string]interface{}) (int, error) {
+	var bulkModels []mongo.WriteModel
+
+	for i := 0; i < len(contents); i++ {
+		bulkModels = append(bulkModels, mongo.NewInsertOneModel().SetDocument(contents))
+	}
+
+	ctx := context.TODO()
+	_, err := collection.BulkWrite(ctx, bulkModels)
+
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 		return 0, err
 	}
-	count, err := collection.Count()
+	count, err := collection.CountDocuments(ctx, bson.D{})
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 		return 0, err
 	}
-	return count, nil
+	return int(count), nil
 }

--- a/json/json_import_test.go
+++ b/json/json_import_test.go
@@ -1,18 +1,19 @@
 package json
 
 import (
-	"log"
+	"context"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/mgo.v2"
 )
 
 // TestJsonImport test function for json mongodb import
 func TestJsonImport(t *testing.T) {
 	contents, _ := JSONFileReader("test.json")
 	type args struct {
-		collection *mgo.Collection
+		collection *mongo.Collection
 		contents   map[string]interface{}
 	}
 	tests := []struct {
@@ -35,22 +36,14 @@ func TestJsonImport(t *testing.T) {
 }
 
 // test function to get mongo collection
-func getJsonCollection() *mgo.Collection {
-	session, err := mgo.Dial("localhost")
+func getJsonCollection() *mongo.Collection {
+	serveAPI := options.ServerAPI(options.ServerAPIVersion1)
+	opts := options.Client().ApplyURI("mongodb://localhost:27017/?directConnection=true").SetServerAPIOptions(serveAPI)
+	client, err := mongo.Connect(context.TODO(), opts)
 	if err != nil {
-		log.Printf("Failed to establish connection to MongoDB: %v", err)
+		panic(err)
 		return nil
 	}
-	defer session.SetMode(mgo.Monotonic, true)
-	coll := session.DB("jsontest").C("json-colls")
-	return coll
+	collection := client.Database("admin").Collection("json")
+	return collection
 }
-
-// Running tool: C:\Program Files\Go\bin\go.exe test -timeout 30s -run ^TestJsonImport$ github.com/Livingstone-Billy/mongo-import
-
-// === RUN   TestJsonImport
-// === RUN   TestJsonImport/should_return_collection_count_after_insertion
-// --- PASS: TestJsonImport/should_return_collection_count_after_insertion (0.40s)
-// --- PASS: TestJsonImport (0.43s)
-// PASS
-// ok      github.com/Livingstone-Billy/mongo-import       0.499s


### PR DESCRIPTION
## Overview
This pull request addresses issue #1 introduces several enhancements and rewrites all the functions requiring connections to mongodb from mgo.v2 to mongo-driverv1.12.1

## Changes made
- Rewrite CSVImport which is responsible for importing csv records from csv file and write into mongodb collection.
- Rewrite JSONImport which is responsible for importing json entries from json file and write into mongodb collection

## Related Issues
Closes #1 and fixes the issue that prompted this pull request

## Testing
- Performed extensive unit and compatibility testing to ensure the package performs correctly
- New tests were written for package based on mongo-driverv1.12.1

## Additional Notes
This pull request is part of a larger effort to improve the package's performance and efficiency